### PR TITLE
Ask for the template on the correct url.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,7 +54,7 @@ class foreman_scap_client(
   package { 'foreman_scap_client': } ->
   file { 'foreman_scap_client':
     path    => '/etc/foreman_scap_client/config.yaml',
-    content => template('openscap/config.yaml.erb'),
+    content => template('foreman_scap_client/config.yaml.erb'),
     owner   => 'root',
     ensure  => present,
   }


### PR DESCRIPTION
Addressing:
Could not retrieve catalog from remote server: Error 400 on SERVER:
Could not find template 'openscap/config.yaml.erb' at /etc/puppet/modules/foreman_scap_client/manifests/init.pp:57
