### PR TITLE
change the manifest to have rubygem

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -51,7 +51,7 @@ class foreman_scap_client(
     }].to_yaml %>')
   $policies_data = parseyaml($policies_yaml)
 
-  package { 'foreman_scap_client': } ->
+  package { 'rubygem-foreman_scap_client': } ->
   file { 'foreman_scap_client':
     path    => '/etc/foreman_scap_client/config.yaml',
     content => template('foreman_scap_client/config.yaml.erb'),


### PR DESCRIPTION
Change so the rubygem package will be installed as foreman_scap_client is available only for Fedora (whereas rubygem-foreman_scap_client is available for fedora, rhel, etc.)
