### PR TITLE
Fixes #12304 - Support older ruby versions for array to hash in facter

### DIFF
--- a/lib/facter/rh_certificates.rb
+++ b/lib/facter/rh_certificates.rb
@@ -7,7 +7,7 @@ def extract_certificates_from_subscription_manager
   return nil if data.nil?
   data = data.gsub("\n", "").gsub(/[\[\]]/, "")
   data_array = data.scan(/(\S+)\s*=\s* ([^ ]+)/)
-  data_hash = Hash[data_array]
+  data_hash = Hash[*data_array.flatten]
   consumer_cert_dir = data_hash["consumercertdir"]
   certificates[:repo_ca_cert]          = data_hash["repo_ca_cert"] unless data_hash["repo_ca_cert"] == rh_default_ca_cert
   certificates[:host_certificate_path] = consumer_cert_dir + certificate_end_path


### PR DESCRIPTION
Tested with Rubies: 1.8.5, 1.9.3, 2.0.0, 2.1.0
