### PR TITLE
added /bin to remove_foreman_scap_client_cron path

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -62,6 +62,6 @@ class foreman_scap_client(
   exec { 'remove_foreman_scap_client_cron':
     command => "sed -i '/foreman_scap_client/d' /var/spool/cron/root",
     onlyif  => "grep -c 'foreman_scap_client' /var/spool/cron/root",
-    path    => "/usr/bin",
+    path    => "/bin:/usr/bin",
   }
 }


### PR DESCRIPTION
Added /bin to the remove_foreman_scap_client_cron exec block, because sed and grep live in /bin in RHEL/CentOS 6. Only looking in /usr/bin caused this module to fail with "Could not evaluate: Could not find command 'grep'" on those systems.
