### PR TITLE
Fix for strict_vars option and minor puppet-lint cleanup

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -79,7 +79,7 @@ class foreman_scap_client(
     } else {
       $_osfamily = $::osfamily? {
         'Fedora' => 'f',
-         default => 'el'
+        default => 'el'
       }
       $baseurl = "http://yum.theforeman.org/plugins/${foreman_repo_rel}/${_osfamily}${::operatingsystemmajrelease}/\$basearch"
     }
@@ -96,23 +96,23 @@ class foreman_scap_client(
 
   package { 'rubygem-foreman_scap_client': ensure => $ensure, } ->
   file { 'foreman_scap_client':
+    ensure  => present,
     path    => '/etc/foreman_scap_client/config.yaml',
     content => template('foreman_scap_client/config.yaml.erb'),
     owner   => 'root',
-    ensure  => present,
   }
 
   file { 'foreman_scap_client_cron':
+    ensure  => present,
     path    => '/etc/cron.d/foreman_scap_client_cron',
     content => template('foreman_scap_client/cron.erb'),
     owner   => 'root',
-    ensure  => present,
   }
 
   # Remove crons previously installed here
   exec { 'remove_foreman_scap_client_cron':
     command => "sed -i '/foreman_scap_client/d' /var/spool/cron/root",
     onlyif  => "grep -c 'foreman_scap_client' /var/spool/cron/root",
-    path    => "/bin:/usr/bin",
+    path    => '/bin:/usr/bin',
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,12 +1,13 @@
+# Params class for parent foreman_scap_client
 class foreman_scap_client::params {
-  $downcased_fqdn = downcase($fqdn)
+  $downcased_fqdn = downcase($::fqdn)
   if versioncmp('4.0.0', $clientversion) > 0 {
     $ssl_dir = '/var/lib/puppet/ssl'
   } else {
     $ssl_dir = '/etc/puppetlabs/puppet/ssl'
   }
 
-  $ca_file          = pick($::rh_certificate_repo_ca_file, "${ssl_dir}/certs/ca.pem")
-  $host_certificate = pick($::rh_certificate_consumer_host_cert, "${ssl_dir}/certs/${$downcased_fqdn}.pem")
-  $host_private_key = pick($::rh_certificate_consumer_host_key, "${ssl_dir}/private_keys/${$downcased_fqdn}.pem")
+  $ca_file          = pick($facts['rh_certificate_repo_ca_file'], "${ssl_dir}/certs/ca.pem")
+  $host_certificate = pick($facts['rh_certificate_consumer_host_cert'], "${ssl_dir}/certs/${$downcased_fqdn}.pem")
+  $host_private_key = pick($facts['rh_certificate_consumer_host_key'], "${ssl_dir}/private_keys/${$downcased_fqdn}.pem")
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,7 +7,31 @@ class foreman_scap_client::params {
     $ssl_dir = '/etc/puppetlabs/puppet/ssl'
   }
 
-  $ca_file          = pick($facts['rh_certificate_repo_ca_file'], "${ssl_dir}/certs/ca.pem")
-  $host_certificate = pick($facts['rh_certificate_consumer_host_cert'], "${ssl_dir}/certs/${$downcased_fqdn}.pem")
-  $host_private_key = pick($facts['rh_certificate_consumer_host_key'], "${ssl_dir}/private_keys/${$downcased_fqdn}.pem")
+  # Set CA file
+  if defined('$::rh_certificate_repo_ca_file') {
+    $rh_certificate_repo_ca_file = $::rh_certificate_repo_ca_file
+  }
+  else {
+    $rh_certificate_repo_ca_file = undef
+  }
+
+  # Set host cert
+  if defined('$::rh_certificate_consumer_host_cert') {
+    $rh_certificate_consumer_host_cert = $::rh_certificate_consumer_host_cert
+  }
+  else {
+    $rh_certificate_consumer_host_cert = undef
+  }
+
+  # Set private key
+  if defined('$::rh_certificate_consumer_host_key') {
+    $rh_certificate_consumer_host_key = $::rh_certificate_consumer_host_key
+  }
+  else {
+    $rh_certificate_consumer_host_key = undef
+  }
+
+  $ca_file          = pick($rh_certificate_repo_ca_file, "${ssl_dir}/certs/ca.pem")
+  $host_certificate = pick($rh_certificate_consumer_host_cert, "${ssl_dir}/certs/${$downcased_fqdn}.pem")
+  $host_private_key = pick($rh_certificate_consumer_host_key, "${ssl_dir}/private_keys/${$downcased_fqdn}.pem")
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,16 +1,22 @@
 {
   "name": "theforeman-foreman_scap_client",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "author": "theforeman",
   "summary": "This puppet module configures foreman_scap_client.",
-  "license": "GNU General Public License, version 2 (GPLv2)",
+  "license": "GPL-2.0",
   "source": "https://github.com/theforeman/puppet-foreman_scap_client.git",
   "project_page": "https://github.com/theforeman/puppet-foreman_scap_client",
   "issues_url": "https://github.com/theforeman/puppet-foreman_scap_client/issues",
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease" : [ "6.x", "7.x" ]
+    }
+  ]
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.2.0"
+      "version_requirement": ">= 4.2.0 < 5.0.0"
     }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -12,7 +12,7 @@
       "operatingsystem": "RedHat",
       "operatingsystemrelease" : [ "6.x", "7.x" ]
     }
-  ]
+  ],
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
Moved ensure to first line of definition for 'foreman_scap_client_cron' and 'foreman_scap_client' files, per Puppet Style Guide 9.3

Removed extra space in front of 'default' option in osfamily selection

Switched to single quotes for hardcoded 'path' option in cron removal
section, per Puppet Style Guide 6

Added comment to params.pp, loosely per Puppet Style Guide 7.1

Fixed variable scoping for $fqdn in params.pp, per Puppet Style Guide 13.2

Modified 'rh_certificate_*' variables in params.pp to use facts hash. This
allows the module to be compatible with Puppet's strict vars option.

Mofified metadata.json to fix forge warnings.
- Converted license to SPDX string
- Added os_support key (may need expanded)
- Added upper bound on dependencies