### PR TITLE
These changes allow this module to work with foreman 1.20+

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -100,6 +100,12 @@ class foreman_scap_client(
       }
     }
 
+    if versioncmp($foreman_repo_rel, '1.20') >= 0 {
+      $_reposuffix = 'client'
+    } else {
+      $_reposuffix = 'plugins'
+    }
+
     if $foreman_repo_src {
       $baseurl = $foreman_repo_src
     } else {
@@ -107,13 +113,7 @@ class foreman_scap_client(
         'Fedora' => 'f',
         default => 'el'
       }
-      $baseurl = "http://yum.theforeman.org/client/${foreman_repo_rel}/${_osfamily}${::operatingsystemmajrelease}/\$basearch"
-    }
-
-    if versioncmp($foreman_repo_rel, '1.20') >= 0 {
-      $_reposuffix = 'client'
-    } else {
-      $_reposuffix = 'plugins'
+      $baseurl = "http://yum.theforeman.org/${_reposuffix}/${foreman_repo_rel}/${_osfamily}${::operatingsystemmajrelease}/\$basearch"
     }
 
     yumrepo { "foreman-${_reposuffix}":

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -107,12 +107,18 @@ class foreman_scap_client(
         'Fedora' => 'f',
         default => 'el'
       }
-      $baseurl = "http://yum.theforeman.org/plugins/${foreman_repo_rel}/${_osfamily}${::operatingsystemmajrelease}/\$basearch"
+      $baseurl = "http://yum.theforeman.org/client/${foreman_repo_rel}/${_osfamily}${::operatingsystemmajrelease}/\$basearch"
     }
 
-    yumrepo { 'foreman-plugins':
+    if versioncmp($foreman_repo_rel, '1.20') >= 0 {
+      $_reposuffix = 'client'
+    } else {
+      $_reposuffix = 'plugins'
+    }
+
+    yumrepo { "foreman-${_reposuffix}":
       ensure   => present,
-      descr    => "Foreman plugins ${foreman_repo_rel}",
+      descr    => "Foreman ${_reposuffix} ${foreman_repo_rel}",
       baseurl  => $baseurl,
       gpgkey   => $gpgkey,
       gpgcheck => $foreman_repo_gpg_chk,


### PR DESCRIPTION
Starting with foreman 1.20, the rubygem-foreman_scap_client resides in a different repository called foreman-client.  I added a version check to allow backwards compatibility for <1.20.