### PR TITLE
Add pdk to development dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,4 @@ gem 'puppetlabs_spec_helper', '>= 0.8.0'
 gem 'metadata-json-lint', :require => false
 gem 'rspec-puppet-facts', '~> 1.7', :require => false
 gem 'puppet-blacksmith', '>= 3.1.0', {"groups"=>["development"]}
+gem 'pdk', '~> 1.12.0', {"groups"=>["development"]}


### PR DESCRIPTION
pdk is needed for automated releases,
we should have it in development
dependencies.