### PR TITLE
Allow switching provider for Package installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ of foreman_scap_client.
   Unless set to an alternative file source, URL will be used.
 * 'foreman_repo_src':  Alternative baseurl for The Foreman plugins repository
 * 'foreman_repo_gpg_chk': Enable / disable GPG checks. Directly passed to Yumrepo resource
+* 'package_name': Name of the package that will be installed. The default is platform specific.
+* 'package_provider': Puppet provider to use to install the package, defaults to automatic detection
 * 'install_options': Additional options for client package installation
 * 'cron_template': Path to cron template
 * 'cron_splay': Upper limit for splay time when sending reports to proxy

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,6 +27,10 @@
 # @param package_name
 #   os dependent package name for rubygem-foreman_scap_client package
 #
+# @param package_provider 
+#   provider for the package, defaults to yum but can be set to gem, or any other valid
+#   puppet package provider
+#
 # @param foreman_repo_rel
 #   add / manage foreman-plugins yum repo and set to release version. Eg  '1.14'
 #
@@ -107,6 +111,7 @@ class foreman_scap_client(
   Stdlib::Absolutepath $host_certificate = $::foreman_scap_client::params::host_certificate,
   Stdlib::Absolutepath $host_private_key = $::foreman_scap_client::params::host_private_key,
   String $package_name = $::foreman_scap_client::params::package_name,
+  Optional[String] $package_provider = undef,
   Optional[String] $foreman_repo_rel = undef,
   String $foreman_repo_key = 'https://yum.theforeman.org/RPM-GPG-KEY-foreman',
   Optional[String] $foreman_repo_src = undef,
@@ -163,6 +168,7 @@ class foreman_scap_client(
   package { $package_name:
     ensure          => $ensure,
     install_options => $install_options,
+    provider        => $package_provider,
   }
   -> file { '/etc/foreman_scap_client':
     ensure => directory,


### PR DESCRIPTION
Adds the package_provider option which allows you define the provider for the package installation, this makes this module work on Centos 7 by allowing a change to 
```
## Foreman SCAP client settings
foreman_scap_client::package_provider: 'gem'
foreman_scap_client::package_name: 'foreman_scap_client'
```
Also updates the README adding in the missing `package_name` option