### PR TITLE
Correct specs context

### DIFF
--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -4,18 +4,18 @@ describe 'foreman_scap_client' do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) { facts}
-    end
 
-    context 'with minimal parameters' do
-      let(:params) do
-        {
-          server: 'foreman-proxy.example.com',
-          port: 8443,
-          policies: {},
-        }
+      context 'with minimal parameters' do
+        let(:params) do
+          {
+            server: 'foreman-proxy.example.com',
+            port: 8443,
+            policies: [],
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
       end
-
-      it { is_expected.to compile.with_all_deps }
     end
   end
 end


### PR DESCRIPTION
The facts need to be defined within the OS context