### PR TITLE
Drop EOL Puppet versions and require >= 5.5.8; use data types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 Gemfile.lock
 .idea
+.yardoc
+REFERENCE.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,8 @@
 ---
 bundler_args: --without system_tests development
-sudo: false
 matrix:
   fast_finish: true
   include:
-    - rvm: 2.0.0
-      env: PUPPET_VERSION=3.8
-    - rvm: 2.1.9
-      env: PUPPET_VERSION=4.9
     - rvm: 2.4.1
       env: PUPPET_VERSION=5.0
     - rvm: 2.5.1

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ end
 gem 'rake'
 gem 'puppet', puppetversion
 gem 'puppetlabs_spec_helper', '>= 0.8.0'
+gem 'puppet-strings', :require => false
 gem 'metadata-json-lint', :require => false
 gem 'rspec-puppet-facts', '~> 1.7', :require => false
 gem 'puppet-blacksmith', '>= 3.1.0', {"groups"=>["development"]}

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 if ENV.key?('PUPPET_VERSION')
   puppetversion = "~> #{ENV['PUPPET_VERSION']}"
 else
-  puppetversion = ['>= 2.6']
+  puppetversion = ['>= 5.5.8']
 end
 
 gem 'rake'

--- a/README.md
+++ b/README.md
@@ -72,5 +72,6 @@ We use project blacksmith to do the release. All you need to do is configuring t
 credentials in ~/.puppetforge.yml and then call release task from upstream repo like this
 
 ```
+bundle exec rake strings:generate:reference
 bundle exec rake module:release
 ```

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,11 +1,7 @@
 # Params class for parent foreman_scap_client
 class foreman_scap_client::params {
   $downcased_fqdn = downcase($::fqdn)
-  if versioncmp('4.0.0', $clientversion) > 0 {
-    $ssl_dir = '/var/lib/puppet/ssl'
-  } else {
-    $ssl_dir = '/etc/puppetlabs/puppet/ssl'
-  }
+  $ssl_dir = '/etc/puppetlabs/puppet/ssl'
 
   # Set CA file
   if defined('$::rh_certificate_repo_ca_file') {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,6 +1,7 @@
 # Params class for parent foreman_scap_client
+# @api private
 class foreman_scap_client::params {
-  $downcased_fqdn = downcase($::fqdn)
+  $downcased_fqdn = downcase($facts['fqdn'])
   $ssl_dir = '/etc/puppetlabs/puppet/ssl'
 
   # Set CA file
@@ -27,7 +28,7 @@ class foreman_scap_client::params {
     $rh_certificate_consumer_host_key = undef
   }
 
-  $package_name = $::osfamily ? {
+  $package_name = $facts['osfamily'] ? {
     'Debian' => 'ruby-foreman-scap-client',
     default  => 'rubygem-foreman_scap_client'
   }

--- a/metadata.json
+++ b/metadata.json
@@ -33,7 +33,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.8.7 < 7.0.0"
+      "version_requirement": ">= 5.5.8 < 7.0.0"
     }
   ],
   "dependencies": [


### PR DESCRIPTION
All versions older than this are EOL and there's no need to maintain compatibility with them.

Using puppet-strings style documentation allows easily generating a `REFERENCE.md` using `bundle exec rake strings:generate:reference`. If this is done before releasing, the forge will also nicely render this. I've kept the same data in `README.md` but it will be redundant on a release.

The data types can use a check to see if they make sense.