### PR TITLE
Allow stdlib 6.x and require 4.25.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -39,7 +39,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.2.0 < 6.0.0"
+      "version_requirement": ">= 4.25.0 < 7.0.0"
     }
   ]
 }


### PR DESCRIPTION
5665cb18af7b66b79010d75f7e99680d26aadf33 started to use data types introduced in 4.25.0 so this only reflects that.

Version 6.0 was breaking because it moved the Puppet lower version bound from 2.7.0 to 5.5.10. This module requires 5.5.8 so that's not a real concern.