### PR TITLE
Confine custom fact to only execute on Linux systems

### DIFF
--- a/lib/facter/rh_certificates.rb
+++ b/lib/facter/rh_certificates.rb
@@ -1,4 +1,5 @@
 Facter.add('rh_certificate') do
+  confine kernel: 'Linux'
   setcode do
     data = Facter::Util::Resolution.exec('/usr/sbin/subscription-manager config')
     break if data.nil? || data.empty?


### PR DESCRIPTION
This module can also be used to configure Foreman SCAP clients via an external Puppet server, separate to Foreman/Satellite.

Because an external Puppet server may also manage Windows systems, the Windows systems attempt to resolve this fact and it produces this error in Puppet run logs: 

"Facter
Error while resolving custom fact fact='rh_certificate', resolution='': break from proc-closure"

This can be easily avoided by confining the custom fact to execute only for systems whose kernel fact value is "Linux".

Reference: https://www.puppet.com/docs/puppet/8/custom_facts.html#confining-facts